### PR TITLE
init flow steering even when autoscale is disabled

### DIFF
--- a/tas/fast/fast_kernel.c
+++ b/tas/fast/fast_kernel.c
@@ -123,7 +123,7 @@ void fast_kernel_packet(struct dataplane_context *ctx,
   len = network_buf_len(nbh);
   dma_write(krx->addr, len, network_buf_bufoff(nbh));
 
-  if (network_buf_flowgroup(nbh, &krx->msg.packet.flow_group)) {
+  if (network_buf_flowgroup(nbh, &krx->msg.packet.flow_group, ctx->id)) {
     fprintf(stderr, "fast_kernel_packet: network_buf_flowgroup failed\n");
     abort();
   }

--- a/tas/fast/network.h
+++ b/tas/fast/network.h
@@ -187,15 +187,15 @@ static inline uint16_t network_buf_tcpxsums(struct network_buf_handle *bh, uint8
 }
 
 static inline int network_buf_flowgroup(struct network_buf_handle *bh,
-    uint16_t *fg)
+    uint16_t *fg, uint16_t core)
 {
   struct rte_mbuf *mb = (struct rte_mbuf *) bh;
   if (!(mb->ol_flags & PKT_RX_RSS_HASH)) {
-    *fg = 0;
+    *fg = core;
     return 0;
   }
 
-  *fg = mb->hash.rss & (rss_reta_size - 1);
+  *fg = mb->hash.rss & (rss_reta_size - 1); // NOTE: assume rte_is_power_of_2(rss_reta_size)
   return 0;
 }
 

--- a/tas/tas.c
+++ b/tas/tas.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     res = EXIT_FAILURE;
     goto error_exit;
   }
-  fp_cores_max = config.fp_cores_max;
+  fp_cores_max = fp_cores_cur = config.fp_cores_max;
 
   /* allocate shared memory before dpdk grabs all huge pages */
   if (shm_preinit() != 0) {


### PR DESCRIPTION
Flow steering index is uninitialized when fastpath autoscaling is disabled. This causes TX traffic to be forwarded to other cores and thus also causes contention on the flow state lock. 

Fixes #13 

Signed-off-by: Rajath Shashidhara <rajaths@cs.utexas.edu>